### PR TITLE
add return type definitions for createAsset API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,13 +59,17 @@ function clear(cache: PromiseCache[], ...args: any[]) {
   }
 }
 
-function createAsset(fn: PromiseFn, lifespan = 0) {
+function createAsset<T>(fn: PromiseFn, lifespan = 0) {
   const cache: PromiseCache[] = []
   return {
-    read: (...args: any[]) => handleAsset(fn, cache, args, lifespan),
-    preload: (...args: any[]) => void handleAsset(fn, cache, args, lifespan, true),
+    /**
+     * @throws Suspense Promise if asset is not yet ready
+     * @throws Error if the promise rejected for some reason 
+     */
+    read: (...args: any[]): T => handleAsset(fn, cache, args, lifespan),
+    preload: (...args: any[]): void => void handleAsset(fn, cache, args, lifespan, true),
     clear: (...args: any[]) => clear(cache, ...args),
-    peek: (...args: any[]) => cache.find((entry) => deepEqual(args, entry.args))?.response,
+    peek: (...args: any[]): void | T => cache.find((entry) => deepEqual(args, entry.args))?.response,
   }
 }
 


### PR DESCRIPTION
This allows the user to use an asset (especially useful for one that is exposed by a package) without knowing the type beforehand.

For example, in package:

```ts

type SubscriptionAsset = {
  computation: Tracker.Computation
  subscription: Meteor.SubscriptionHandle
}

export const subscriptions = createAsset<SubscriptionAsset>( ( name, ...args ) => {
  // ...
})
```

In user code (no knowledge of `type SubscriptionAsset`):

<img width="505" alt="Screenshot 2020-11-05 at 11 31 14" src="https://user-images.githubusercontent.com/159500/98229635-7081bb00-1f5a-11eb-942e-b886eb34a5bc.png">

I also added JSDocs for the throw behaviour:

<img width="582" alt="Screenshot 2020-11-05 at 11 29 30" src="https://user-images.githubusercontent.com/159500/98229685-81cac780-1f5a-11eb-8bc6-26ce971ca370.png">
